### PR TITLE
To decode to binary data from base64

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -9,7 +9,15 @@ function commandIsAllowed(c) {
 	return typeof base64[command] === 'function'
 }
 
-if (!command || !input || !commandIsAllowed(command)) {
+function binarydecode(i) {
+ return Buffer.from(base64['unescape'](i), 'base64')
+}
+
+if ( command && input && command === 'binarydecode') {
+
+	process.stdout.write(binarydecode(input))
+
+} else if (!command || !input || !commandIsAllowed(command)) {
 	console.log('Missing required parameters. Run like:')
 	console.log('base64url [encode|decode|escape|unescape] [input]')
 	console.log('E.g., run this: base64url decode Tm9kZS5qcyBpcyBhd2Vzb21lLg')


### PR DESCRIPTION
base64["decode"] function converted to utf-8. Therefore binary data out of uft-8 from base64 was broken.  I used private key binary data and but the decoding binary did not work. 
This pull request to add  binarydecode option to avoid to encoding utf-8 and show the binary data as it is.  